### PR TITLE
Add missing iam_instance_profile and depends_on to m6_solution nginx2…

### DIFF
--- a/m6_solution/instances.tf
+++ b/m6_solution/instances.tf
@@ -39,6 +39,8 @@ resource "aws_instance" "nginx2" {
   instance_type          = var.instance_type
   subnet_id              = aws_subnet.subnet2.id
   vpc_security_group_ids = [aws_security_group.nginx-sg.id]
+  iam_instance_profile   = aws_iam_instance_profile.nginx_profile.name
+  depends_on             = [aws_iam_role_policy.allow_s3_all]
 
   user_data = <<EOF
 #! /bin/bash


### PR DESCRIPTION
fixes: #29 

This fixes an issue in the m6_solution config where one instance (nginx1) is always healthy, and the second instance (nginx2) is always unhealthy. 